### PR TITLE
Cxx11SGXDemo: Fix build error

### DIFF
--- a/sample/Cxx11SGXDemo/CMakeLists.txt
+++ b/sample/Cxx11SGXDemo/CMakeLists.txt
@@ -9,7 +9,7 @@ if(SGX_HW AND SGX_MODE STREQUAL "Release")
 else()
     set(LDS Enclave/Enclave_debug.lds)
 endif()
-add_trusted_library(trusted_lib SRCS ${T_SRCS} EDL Enclave/TrustedLibrary/Libcxx.edl EDL_SEARCH_PATHS ${EDL_SEARCH_PATHS})
+add_trusted_library(trusted_lib SRCS ${T_SRCS} EDL Enclave/Enclave.edl EDL_SEARCH_PATHS ${EDL_SEARCH_PATHS})
 add_enclave_library(enclave SRCS ${E_SRCS} TRUSTED_LIBS trusted_lib EDL Enclave/Enclave.edl EDL_SEARCH_PATHS ${EDL_SEARCH_PATHS} LDSCRIPT ${LDS})
 enclave_sign(enclave KEY Enclave/Enclave_private.pem CONFIG Enclave/Enclave.config.xml)
 


### PR DESCRIPTION
- use Enclave.edl instead of Libcxx.edl
- Libcxx.cpp includes Enclave_t.h, not Libcxx_t.h