### PR TITLE
add enclave_sign as dependencies of untrusted_executable

### DIFF
--- a/sample/Cxx11SGXDemo/CMakeLists.txt
+++ b/sample/Cxx11SGXDemo/CMakeLists.txt
@@ -15,3 +15,4 @@ enclave_sign(enclave KEY Enclave/Enclave_private.pem CONFIG Enclave/Enclave.conf
 
 set(SRCS App/App.cpp App/TrustedLibrary/Libcxx.cpp)
 add_untrusted_executable(Cxx11SGXDemo SRCS ${SRCS} EDL Enclave/Enclave.edl EDL_SEARCH_PATHS ${EDL_SEARCH_PATHS})
+add_dependencies(Cxx11SGXDemo enclave-sign)

--- a/sample/LocalAttestation/CMakeLists.txt
+++ b/sample/LocalAttestation/CMakeLists.txt
@@ -41,3 +41,4 @@ add_untrusted_executable(LocalAttestation
                          EDL Enclave1/Enclave1.edl Enclave2/Enclave2.edl Enclave3/Enclave3.edl
                          EDL_SEARCH_PATHS ${EDL_SEARCH_PATHS})
 target_link_libraries(LocalAttestation UntrustedLocalAttestation)
+add_dependencies(LocalAttestation Enclave1-sign Enclave2-sign Enclave3-sign)


### PR DESCRIPTION
It doesn't matter if you always run `make all`

However, in clion (and maybe some other IDE), we have to build & sign enclaves manually before running the app without the `add_dependencies`.

With dependency relationship specified, clion may build & sign enclaves automatically.