### PR TITLE
fix link problem when building trusted library

### DIFF
--- a/cmake/FindSGX.cmake
+++ b/cmake/FindSGX.cmake
@@ -128,7 +128,6 @@ if(SGX_FOUND)
 
         target_link_libraries(${target} "${SGX_COMMON_CFLAGS} \
             -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L${SGX_LIBRARY_PATH} \
-            -Wl,--whole-archive -l${SGX_TRTS_LIB} -Wl,--no-whole-archive \
             -Wl,--start-group -lsgx_tstdc -lsgx_tcxx -lsgx_tkey_exchange -lsgx_tcrypto -l${SGX_TSVC_LIB} -Wl,--end-group \
             -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
             -Wl,-pie,-eenclave_entry -Wl,--export-dynamic \


### PR DESCRIPTION
The previous code of "add_trusted_library" will always link sgx_trts.a, which causes multiple definition linkage problem when using the built trusted library in an enclave.

This fix is to remove the sgx_trts in add_trusted_library. Seems work to me. 