### PR TITLE
Make edger8r command depend on EDL file

### DIFF
--- a/cmake/FindSGX.cmake
+++ b/cmake/FindSGX.cmake
@@ -94,6 +94,7 @@ if(SGX_FOUND)
         endif()
         add_custom_command(OUTPUT ${EDL_T_C}
                            COMMAND ${SGX_EDGER8R} ${USE_PREFIX} --trusted ${EDL_ABSPATH} --search-path ${SEARCH_PATHS}
+                           MAIN_DEPENDENCY ${EDL_ABSPATH}
                            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
         add_library(${target}-edlobj OBJECT ${EDL_T_C})


### PR DESCRIPTION
I have yet to figure out a way to create a target so users can add dependencies onto their included header and EDL files, but, regardless, edger8r should certainly be rerun if the main EDL file itself changes.