### PR TITLE
Add error-ignoring options to enclave_sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ add_trusted_library(target
 # default one-step signing output enclave name is target.signed.so, change it with OUTPUT option.
 enclave_sign(target
              KEY key
-             CONFIG config
+	     [IGNORE_INIT]
+	     [IGNORE_REL]
+             [CONFIG config]
              [OUTPUT file_name])
 
 # build untrusted executable to run with enclave


### PR DESCRIPTION
I also updated the README to account for CONFIG being optional and to add the two new options for ignoring `.init` sections and text relocation. I haven't confirmed this works on two-step signing.