### PR TITLE
Quote SGX_EDL_SEARCH_PATHS

### DIFF
--- a/cmake/FindSGX.cmake
+++ b/cmake/FindSGX.cmake
@@ -121,7 +121,7 @@ if(SGX_FOUND)
             if("${SGX_EDL_SEARCH_PATHS}" STREQUAL "")
                 message("${target}: SGX enclave edl file search paths are not provided!")
             endif()
-            _build_edl_obj(${SGX_EDL} ${SGX_EDL_SEARCH_PATHS} ${SGX_USE_PREFIX})
+            _build_edl_obj(${SGX_EDL} "${SGX_EDL_SEARCH_PATHS}" ${SGX_USE_PREFIX})
             add_library(${target} STATIC ${SGX_SRCS} $<TARGET_OBJECTS:${target}-edlobj>)
         endif()
         
@@ -154,7 +154,7 @@ if(SGX_FOUND)
             set(LDSCRIPT_FLAG "-Wl,--version-script=${LDS_ABSPATH}")
         endif()
 
-        _build_edl_obj(${SGX_EDL} ${SGX_EDL_SEARCH_PATHS} ${SGX_USE_PREFIX})
+        _build_edl_obj(${SGX_EDL} "${SGX_EDL_SEARCH_PATHS}" ${SGX_USE_PREFIX})
 
         add_library(${target} SHARED ${SGX_SRCS} $<TARGET_OBJECTS:${target}-edlobj>)
         set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${ENCLAVE_CXX_FLAGS})


### PR DESCRIPTION
Oops, my previous PR to make EDL_SEARCH_PATHS optional didn't actually handle it right. The quotes shouldn't affect parsing when the variable is provided (at least, the sample code works).