### PR TITLE
Update minimum CMake version and use include directories instead of flags

### DIFF
--- a/cmake/FindSGX.cmake
+++ b/cmake/FindSGX.cmake
@@ -70,11 +70,11 @@ if(SGX_FOUND)
         message(FATAL_ERROR "SGX_MODE ${SGX_MODE} is not Debug, PreRelease or Release.")
     endif()
 
-    set(ENCLAVE_INC_FLAGS "-I${SGX_INCLUDE_DIR} -I${SGX_TLIBC_INCLUDE_DIR} -I${SGX_LIBCXX_INCLUDE_DIR}")
-    set(ENCLAVE_C_FLAGS "${SGX_COMMON_CFLAGS} -nostdinc -fvisibility=hidden -fpie -fstack-protector-strong ${ENCLAVE_INC_FLAGS}")
+    set(ENCLAVE_INC_DIRS "${SGX_INCLUDE_DIR}" "${SGX_TLIBC_INCLUDE_DIR}" "${SGX_LIBCXX_INCLUDE_DIR}")
+    set(ENCLAVE_C_FLAGS "${SGX_COMMON_CFLAGS} -nostdinc -fvisibility=hidden -fpie -fstack-protector-strong")
     set(ENCLAVE_CXX_FLAGS "${ENCLAVE_C_FLAGS} -nostdinc++")
 
-    set(APP_INC_FLAGS "-I${SGX_PATH}/include")
+    set(APP_INC_DIRS "${SGX_PATH}/include")
     set(APP_C_FLAGS "${SGX_COMMON_CFLAGS} -fPIC -Wno-attributes ${APP_INC_FLAGS}")
     set(APP_CXX_FLAGS "${APP_C_FLAGS}")
 
@@ -99,7 +99,7 @@ if(SGX_FOUND)
 
         add_library(${target}-edlobj OBJECT ${EDL_T_C})
         set_target_properties(${target}-edlobj PROPERTIES COMPILE_FLAGS ${ENCLAVE_C_FLAGS})
-        target_include_directories(${target}-edlobj PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+        target_include_directories(${target}-edlobj PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ENCLAVE_INC_DIRS})
 
         set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/${EDL_NAME}_t.h")
     endfunction()
@@ -126,7 +126,7 @@ if(SGX_FOUND)
         endif()
         
         set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${ENCLAVE_CXX_FLAGS})
-        target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+        target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ENCLAVE_INC_DIRS})
 
         target_link_libraries(${target} "${SGX_COMMON_CFLAGS} \
             -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L${SGX_LIBRARY_PATH} \
@@ -158,7 +158,7 @@ if(SGX_FOUND)
 
         add_library(${target} SHARED ${SGX_SRCS} $<TARGET_OBJECTS:${target}-edlobj>)
         set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${ENCLAVE_CXX_FLAGS})
-        target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+        target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ENCLAVE_INC_DIRS})
 
         set(TLIB_LIST "")
         foreach(TLIB ${SGX_TRUSTED_LIBS})
@@ -264,7 +264,7 @@ if(SGX_FOUND)
 
         add_library(${target} ${mode} ${SGX_SRCS} ${EDL_U_SRCS})
         set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${APP_CXX_FLAGS})
-        target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+        target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${APP_INC_DIRS})
         target_link_libraries(${target} "${SGX_COMMON_CFLAGS} \
                                          -L${SGX_LIBRARY_PATH} \
                                          -l${SGX_URTS_LIB} \
@@ -313,7 +313,7 @@ if(SGX_FOUND)
 
         add_executable(${target} ${SGX_SRCS} ${EDL_U_SRCS})
         set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${APP_CXX_FLAGS})
-        target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+        target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${APP_INC_DIRS})
         target_link_libraries(${target} "${SGX_COMMON_CFLAGS} \
                                          -L${SGX_LIBRARY_PATH} \
                                          -l${SGX_URTS_LIB} \

--- a/cmake/FindSGX.cmake
+++ b/cmake/FindSGX.cmake
@@ -1,6 +1,6 @@
 # FindPackage cmake file for Intel SGX SDK
 
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.11) # target_include_directories
 include(CMakeParseArguments)
 
 set(SGX_FOUND "NO")


### PR DESCRIPTION
Per the official documentation, `target_include_directories` wasn't in version [2.8.10](https://cmake.org/cmake/help/v2.8.10/cmake.html#section_Commands) or earlier, but was in [2.8.11](https://cmake.org/cmake/help/v2.8.11/cmake.html#section_Commands).

The motivating reason for the second change is that `CMAKE_INCLUDES` occur earlier than `CMAKE_FLAGS` in the resulting command in the makefile. This caused issues when one header (from Boost) was in the same directory as some standard library ones, thus causing conflicts with SGX SDK files when I included that directory. It's easier to rearrange include directories than flags, and this is more idiomatic anyway.

I haven't tried this on Windows. One possible regression involves [`CMAKE_<LANG>_IMPLICIT_INCLUDE_DIRECTORIES`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_IMPLICIT_INCLUDE_DIRECTORIES.html), but I can't imagine one would install the SDK in such a directory.